### PR TITLE
Add support for custom start file

### DIFF
--- a/bin/thumbsup.js
+++ b/bin/thumbsup.js
@@ -13,6 +13,9 @@ var opts = yargs
     'output': {
       description: 'Output path for the static website',
     },
+    'index': {
+      description: 'Name of the First page in the flow. Defaults to index.html'  
+    },
     'title': {
       description: 'Website title',
       default: 'My gallery'
@@ -61,5 +64,6 @@ index.build({
   originalVideos:  opts['original-videos'] + '' === 'true',
   sortFolders:     opts['sort-folders'],
   css:             opts['css'],
-  googleAnalytics: opts['google-analytics']
+  googleAnalytics: opts['google-analytics'],
+  index:           opts['index']
 });

--- a/src/output-website/generator.js
+++ b/src/output-website/generator.js
@@ -24,9 +24,10 @@ exports.build = function(metadata, opts, callback) {
   function website(callback) {
     var structure = model.create(metadata, opts);
     var homepage  = pages.homepage(structure);
-
+    var index = opts.index || 'index.html';
+    
     var items = [
-      render('index.html', 'homepage', homepage)
+      render(index, 'homepage', homepage)
     ];
 
     structure.forEach(function(folder, index) {


### PR DESCRIPTION
I have my static web site generated using a custom site generator that has configured my S3 bucket to server default.html as the default file. So adding support to thumbsup for specifying custom index file. If not specified, the behavior is the same as before. 